### PR TITLE
add option to pass in schema.graphql file in a configmap

### DIFF
--- a/chart/node-resolver/templates/api-config.yaml
+++ b/chart/node-resolver/templates/api-config.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "common.labels.standard" . | nindent 4 }}
 data:
   NODERESOLVER_SERVER_LISTEN: ":{{ .Values.api.listenPort }}"
+{{- if .Values.schemaFile.override }}
+  NODERESOLVER_SCHEMA: /schema.graphql
+{{- end}}
   NODERESOLVER_SERVER_SHUTDOWN_GRACE_PERIOD: "{{ .Values.api.shutdownGracePeriod }}"
 {{- if .Values.api.tracing.enabled }}
   NODERESOLVER_TRACING_ENABLED: "{{ .Values.api.tracing.enabled }}"
@@ -25,4 +28,16 @@ data:
 {{- end }}
 {{- with .Values.api.trustedProxies }}
   NODERESOLVER_SERVER_TRUSTED_PROXIES: "{{ join " " . }}"
+{{- end }}
+{{- if .Values.schemaFile.override }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}-schema-config
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+data:
+  schema.graphql: |-
+{{ .Values.schemaFile.content | indent 4 }}
 {{- end }}

--- a/chart/node-resolver/templates/deployment.yaml
+++ b/chart/node-resolver/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
               path: /readyz
               port: http
           volumeMounts:
+          {{- if .Values.schemaFile.override }}
+            - name: schema-config-volume
+              mountPath: /schema.graphql
+          {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
       {{- with .Values.api.nodeSelector }}
@@ -85,3 +89,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.schemaFile.override }}
+        - name: schema-config-volume
+          configMap:
+            name: {{ include "common.names.fullname" . }}-schema-config
+      {{- end }}

--- a/chart/node-resolver/values.yaml
+++ b/chart/node-resolver/values.yaml
@@ -29,9 +29,17 @@ ingress:
   hosts: []
   tls: {}
 
+# the default graphql schema is provided by this repo `schema.graphql`, to override this and 
+# mount a new file, set override to true and pass the schema in an additional values file
+schemaFile:
+  override: false
+  content: |
+    # Use values-schema.yaml to override this
+
 api:
   replicas: 1
   listenPort: 7904
+
   extraLabels: {}
   extraAnnotations: {}
   extraEnvVars []:


### PR DESCRIPTION
This adds the ability to add a different schema config that what is provided by default in the repo and will mount it as a volume. 

With the `override: false` , there is no volume/mounts, and will use the default `schema.graphql` location

With `override: true` and `content` set with the schema:

Env var set:
```
data:
  NODERESOLVER_SERVER_LISTEN: ":7904"
  NODERESOLVER_SCHEMA: /schema.graphql
  NODERESOLVER_SERVER_SHUTDOWN_GRACE_PERIOD: "5s"
```

config data set: 

```
...
data:
  schema.graphql: |
    directive @prefixedID(prefix: String!) on OBJECT
    type Annotation implements Node
      @key(fields: "id")
      @prefixedID(prefix: "metaano") {
      id: ID!
    }
...
```

With the deploy volume mounts: 
```
...
          volumeMounts:
            - name: schema-config-volume
              mountPath: /schema.graphql
...
      volumes:
        - name: schema-config-volume
          configMap:
            name: release-name-node-resolver-schema-config
```