### PR TITLE
mount path should be the directory, not the filename

### DIFF
--- a/chart/node-resolver/templates/deployment.yaml
+++ b/chart/node-resolver/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - serve
           {{- if .Values.schemaFile.override }}
             - --schema
-            - /schema.graphql
+            - /app/schema.graphql
           {{- end}}
           ports:
             - name: http
@@ -76,7 +76,8 @@ spec:
           volumeMounts:
           {{- if .Values.schemaFile.override }}
             - name: schema-config-volume
-              mountPath: /schema.graphql
+              mountPath: /app/
+              readOnly: true
           {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}


### PR DESCRIPTION
Prior, there was an error that the requested file was a directory - `mountPath` here is the directory the config is placed, not the full path. 

This was tested in a kubernetes cluster and validated the custom config was picked up